### PR TITLE
Nix flake to build service with fuse3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ virtual*
 original*
 
 Folder*
+
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1742937945,
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           pkgs.pkg-config
           pkgs.fuse3
         ];
+        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 #        PKG_CONFIG_PATH = "${pkgs.fuse3}/lib/pkgconfig";
 #        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.fuse3];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "build for wormhole-service with fuse";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = {nixpkgs, ...}: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    devShells.${system}.build = pkgs.mkShell {
+      packages = [ pkgs.fuse3 pkgs.pkg-config pkgs.cargo pkgs.gcc ];
+      shellHook = ''
+        cargo build --bin wormhole-service
+        exit
+      '';
+    };
+  };
+}
+# use with :
+# nix develop .#build

--- a/flake.nix
+++ b/flake.nix
@@ -1,22 +1,22 @@
 {
-  description = "build for wormhole-service with fuse";
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {nixpkgs, ...}: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs { inherit system; };
-  in {
-    devShells.${system}.build = pkgs.mkShell {
-      packages = [ pkgs.fuse3 pkgs.pkg-config pkgs.cargo pkgs.gcc ];
-      shellHook = ''
-        cargo build --bin wormhole-service
-        exit
-      '';
-    };
-  };
+  outputs = {nixpkgs, flake-utils, ...}:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = [
+          pkgs.cargo
+          pkgs.rustc
+          pkgs.pkg-config
+          pkgs.fuse3
+        ];
+#        PKG_CONFIG_PATH = "${pkgs.fuse3}/lib/pkgconfig";
+#        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.fuse3];
+      };
+    });
 }
-# use with :
-# nix develop .#build

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
         packages = [
           pkgs.cargo
           pkgs.rustc
+          pkgs.rustfmt
           pkgs.pkg-config
           pkgs.fuse3
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,6 @@
           pkgs.fuse3
         ];
         RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-#        PKG_CONFIG_PATH = "${pkgs.fuse3}/lib/pkgconfig";
-#        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.fuse3];
       };
     });
 }


### PR DESCRIPTION
This provide an environment to build the project on nix with a nix flake and direnv.

With the vscode extension [direnv](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv) installed, the vscode extensions such as Rust Analyzer will be able to operate.

Direnv can be enabled globally to update your dependencies when entering the repo. See [setup direnv](https://direnv.net/docs/hook.html). If you enable direnv globally and launch vscode from a direnv enabled commandline, the direnv vscode extension is not needed.

If you do not wish to use direnv globally, in an external shell with nix, one can use the following command to enter a shell will all needed dependencies.
```sh
nix develop
```