### PR TITLE
Feat: Sent/Error feedback on ToNetworkMessage::SpecificMessage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,25 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {nixpkgs, flake-utils, ...}:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      devShells.default = pkgs.mkShell {
-        packages = [
-          pkgs.cargo
-          pkgs.rustc
-          pkgs.rustfmt
-          pkgs.pkg-config
-          pkgs.fuse3
-        ];
-        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-      };
-    });
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      # let pkgs = nixpkgs.legacyPackages.${system};
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.rustfmt
+            pkgs.pkg-config
+            pkgs.fuse3
+          ];
+          RUST_SRC_PATH =
+            "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+        };
+      });
 }

--- a/src/fuse/fuse_impl.rs
+++ b/src/fuse/fuse_impl.rs
@@ -1,12 +1,11 @@
 use crate::pods::arbo::{FsEntry, Inode, Metadata};
-use crate::pods::fs_interface::{self, FsInterface, SimpleFileType};
+use crate::pods::fs_interface::{FsInterface, SimpleFileType};
 use crate::pods::whpath::WhPath;
 use fuser::{
     BackgroundSession, FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData,
     ReplyDirectory, ReplyEntry, Request, TimeOrNow,
 };
 use libc::{EIO, ENOENT};
-use log::debug;
 use std::ffi::OsStr;
 use std::io;
 use std::sync::Arc;
@@ -38,45 +37,6 @@ impl Into<SimpleFileType> for FileType {
     }
 }
 
-const MOUNT_DIR_ATTR: FileAttr = FileAttr {
-    ino: 1,
-    size: 0,
-    blocks: 0,
-    atime: UNIX_EPOCH, // 1970-01-01 00:00:00
-    mtime: UNIX_EPOCH,
-    ctime: UNIX_EPOCH,
-    crtime: UNIX_EPOCH,
-    kind: FileType::Directory,
-    perm: 0o755,
-    nlink: 2,
-    uid: 501,
-    gid: 20,
-    rdev: 0,
-    flags: 0,
-    blksize: 512,
-};
-
-pub const TEMPLATE_FILE_ATTR: FileAttr = FileAttr {
-    ino: 2,
-    size: 0,
-    blocks: 1,
-    atime: UNIX_EPOCH, // 1970-01-01 00:00:00
-    mtime: UNIX_EPOCH,
-    ctime: UNIX_EPOCH,
-    crtime: UNIX_EPOCH,
-    kind: FileType::RegularFile,
-    perm: 0o777,
-    nlink: 1,
-    uid: 501,
-    gid: 20,
-    rdev: 0,
-    flags: 0,
-    blksize: 512,
-};
-// ^ placeholders
-
-// const MIRROR_PTH: &str = "./wh_mirror/";
-
 impl Into<FileAttr> for Metadata {
     fn into(self) -> FileAttr {
         FileAttr {
@@ -94,7 +54,7 @@ impl Into<FileAttr> for Metadata {
             gid: self.gid,
             rdev: self.rdev,
             flags: self.flags,
-            blksize: 1,
+            blksize: self.blksize,
         }
     }
 }
@@ -318,15 +278,7 @@ impl Filesystem for FuseController {
             name.to_string_lossy().to_string(),
             SimpleFileType::File,
         ) {
-            Ok((id, _)) => {
-                // creating metadata to return
-                let mut new_attr = TEMPLATE_FILE_ATTR;
-                new_attr.ino = id;
-                new_attr.kind = FileType::RegularFile;
-                new_attr.size = 0;
-
-                reply.entry(&TTL, &new_attr, 0)
-            }
+            Ok(node) => reply.entry(&TTL, &node.meta.into(), 0),
             Err(err) => {
                 log::error!("fuse_impl error: {:?}", err);
                 reply.error(err.raw_os_error().unwrap_or(EIO))
@@ -348,15 +300,7 @@ impl Filesystem for FuseController {
             name.to_string_lossy().to_string(),
             SimpleFileType::Directory,
         ) {
-            Ok((id, _)) => {
-                // creating metadata to return
-                let mut new_attr = TEMPLATE_FILE_ATTR;
-                new_attr.ino = id;
-                new_attr.kind = FileType::Directory;
-                new_attr.size = 0;
-
-                reply.entry(&TTL, &new_attr, 0)
-            }
+            Ok(inode) => reply.entry(&TTL, &inode.meta.into(), 0),
             Err(err) => {
                 log::error!("fuse_impl error: {:?}", err);
                 reply.error(err.raw_os_error().unwrap_or(EIO))
@@ -458,15 +402,7 @@ impl Filesystem for FuseController {
             name.to_string_lossy().to_string(),
             SimpleFileType::File,
         ) {
-            Ok((id, _)) => {
-                // creating metadata to return
-                let mut new_attr = TEMPLATE_FILE_ATTR;
-                new_attr.ino = id;
-                new_attr.kind = FileType::RegularFile;
-                new_attr.size = 0;
-
-                reply.created(&TTL, &new_attr, 0, new_attr.ino, flags as u32);
-            }
+            Ok(inode) => reply.created(&TTL, &inode.meta.into(), 0, inode.id, flags as u32),
             Err(err) => {
                 log::error!("fuse_impl error: {:?}", err);
                 reply.error(err.raw_os_error().unwrap_or(EIO))

--- a/src/network/forward.rs
+++ b/src/network/forward.rs
@@ -17,8 +17,9 @@ pub async fn forward_receiver_to_write<T>(
 {
     while let Some((message, feedback)) = rx.recv().await {
         let serialized = bincode::serialize(&message).unwrap();
+        let sent = write.send(Message::binary(serialized)).await;
         if let Some(feedback) = feedback {
-            let _ = match write.send(Message::binary(serialized)).await {
+            let _ = match sent {
                 Ok(_) => feedback.send(Feedback::Sent),
                 Err(_) => feedback.send(Feedback::Error),
             };

--- a/src/network/forward.rs
+++ b/src/network/forward.rs
@@ -18,7 +18,7 @@ pub async fn forward_receiver_to_write<T>(
     while let Some((message, feedback)) = rx.recv().await {
         let serialized = bincode::serialize(&message).unwrap();
         if let Some(feedback) = feedback {
-            match write.send(Message::binary(serialized)).await {
+            let _ = match write.send(Message::binary(serialized)).await {
                 Ok(_) => feedback.send(Feedback::Sent),
                 Err(_) => feedback.send(Feedback::Error),
             };

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use tokio::sync::{mpsc::UnboundedSender, oneshot};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::pods::arbo::{ArboIndex, Inode, InodeId, Metadata};
 
@@ -14,14 +14,14 @@ pub enum MessageContent {
     Inode(Inode, InodeId),
     RequestFile(InodeId, Address),
     PullAnswer(InodeId, Vec<u8>),
-    RequestFs(Address),
     Rename(InodeId, InodeId, String, String), //Parent, New Parent, Name, New Name
     EditHosts(InodeId, Vec<Address>),
     AddHosts(InodeId, Vec<Address>),
     RemoveHosts(InodeId, Vec<Address>),
     EditMetadata(InodeId, Metadata, Address),
-    FsAnswer(FileSystemSerialized),
+    RequestFs,
     RequestPull(InodeId),
+    FsAnswer(FileSystemSerialized, Vec<Address>),
 }
 
 pub type MessageAndFeedback = (MessageContent, Option<UnboundedSender<Feedback>>);
@@ -47,10 +47,7 @@ pub enum Feedback {
 #[derive(Debug)]
 pub enum ToNetworkMessage {
     BroadcastMessage(MessageContent),
-    SpecificMessage(
-        MessageAndFeedback,
-        Vec<Address>,
-    ),
+    SpecificMessage(MessageAndFeedback, Vec<Address>),
 }
 
 #[serde_as]

--- a/src/network/peer_ipc.rs
+++ b/src/network/peer_ipc.rs
@@ -12,12 +12,12 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use crate::network::forward::{forward_read_to_sender, forward_receiver_to_write};
 
-use super::message::{Address, FromNetworkMessage, MessageContent};
+use super::message::{Address, FromNetworkMessage, MessageAndFeedback, MessageContent};
 
 pub struct PeerIPC {
     pub address: Address,
     pub thread: tokio::task::JoinHandle<()>,
-    pub sender: mpsc::UnboundedSender<MessageContent>, // send a message to the peer
+    pub sender: mpsc::UnboundedSender<MessageAndFeedback>, // send a message to the peer
                                                        // pub receiver: mpsc::Receiver<NetworkMessage>, // receive a message from the peer
 }
 
@@ -25,7 +25,7 @@ impl PeerIPC {
     async fn work(
         stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
         sender: mpsc::UnboundedSender<FromNetworkMessage>,
-        mut receiver: mpsc::UnboundedReceiver<MessageContent>,
+        mut receiver: mpsc::UnboundedReceiver<MessageAndFeedback>,
         address: Address,
     ) {
         let (write, read) = stream.split();
@@ -39,7 +39,7 @@ impl PeerIPC {
         write: SplitSink<WebSocketStream<TcpStream>, Message>,
         read: SplitStream<WebSocketStream<TcpStream>>,
         sender: mpsc::UnboundedSender<FromNetworkMessage>,
-        mut receiver: mpsc::UnboundedReceiver<MessageContent>,
+        mut receiver: mpsc::UnboundedReceiver<MessageAndFeedback>,
         address: Address,
     ) {
         tokio::join!(

--- a/src/pods/arbo.rs
+++ b/src/pods/arbo.rs
@@ -1,5 +1,4 @@
 use crate::network::message::Address;
-use log::debug;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -106,7 +105,7 @@ impl Inode {
             uid: 0,
             gid: 0,
             rdev: 0,
-            blksize: 0,
+            blksize: 1,
             flags: 0,
         };
 
@@ -142,12 +141,12 @@ impl Arbo {
                     ctime: SystemTime::now(),
                     crtime: SystemTime::now(),
                     kind: SimpleFileType::Directory,
-                    perm: 0o777,
+                    perm: 0o666,
                     nlink: 0,
                     uid: 0,
                     gid: 0,
                     rdev: 0,
-                    blksize: 0,
+                    blksize: 1,
                     flags: 0,
                 },
             },

--- a/src/pods/declarations.rs
+++ b/src/pods/declarations.rs
@@ -2,15 +2,16 @@ use std::{io, sync::Arc};
 
 #[cfg(target_os = "linux")]
 use fuser;
-use log::{debug, info};
+use log::info;
 use parking_lot::RwLock;
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 #[cfg(target_os = "windows")]
 use winfsp::host::FileSystemHost;
 
 #[cfg(target_os = "linux")]
 use crate::fuse::fuse_impl::mount_fuse;
+use crate::network::message::{FileSystemSerialized, FromNetworkMessage, MessageContent};
 #[cfg(target_os = "windows")]
 use crate::winfsp::winfsp_impl::mount_fsp;
 
@@ -43,24 +44,97 @@ pub struct Pod {
     new_peer_handle: Option<JoinHandle<()>>,
 }
 
+pub async fn initiate_connection(
+    peers_addrs: Vec<Address>,
+    server_address: Address,
+    tx: &UnboundedSender<FromNetworkMessage>,
+    rx: &mut UnboundedReceiver<FromNetworkMessage>,
+) -> Option<(FileSystemSerialized, Vec<Address>, PeerIPC)> {
+    if peers_addrs.len() >= 1 {
+        for first_contact in peers_addrs {
+            let first_ipc = PeerIPC::connect(first_contact.to_owned(), tx.clone()).await;
+
+            if let Some(ipc) = first_ipc {
+                if let Err(err) = ipc.sender.send((MessageContent::RequestFs, None)) {
+                    info!(
+                        "Connection with {first_contact} failed: {err}.\n
+                        Trying with next know address"
+                    );
+                    continue;
+                }
+
+                loop {
+                    match rx.recv().await {
+                        Some(FromNetworkMessage {
+                            origin: _,
+                            content: MessageContent::FsAnswer(fs, mut peers_address),
+                        }) => {
+                            // remove itself from peers and first_connect because the connection is already existing
+                            peers_address.retain(|address| {
+                                *address != server_address && *address != first_contact
+                            });
+                            return Some((fs, peers_address, ipc));
+                        }
+                        Some(_) => {
+                            info!(
+                                "First message with {first_contact} failed: His answer is not the FileSystem, corrupted client.\n
+                                Trying with next know address"
+                            );
+                            break;
+                        }
+                        None => continue,
+                    };
+                }
+            }
+        }
+        info!("None of the known address answered correctly, starting a FS.")
+    }
+    None
+}
+
+fn register_to_others(peers: &Vec<PeerIPC>, self_address: &Address) -> std::io::Result<()> {
+    for peer in peers {
+        peer.sender
+            .send((MessageContent::Register(self_address.clone()), None))
+            .map_err(|err| std::io::Error::new(io::ErrorKind::HostUnreachable, err))?;
+    }
+    Ok(())
+}
+
 impl Pod {
     pub async fn new(
         mount_point: WhPath,
         config: PodConfig,
-        mut peers: Vec<Address>,
+        mut know_peers: Vec<Address>,
         server: Arc<Server>,
         server_address: Address,
     ) -> io::Result<Self> {
         log::info!("mount point {}", mount_point);
-        let (arbo, next_inode) =
+        let (mut arbo, next_inode) =
             index_folder(&mount_point, &server_address).expect("unable to index folder");
-        let arbo: Arc<RwLock<Arbo>> = Arc::new(RwLock::new(arbo));
         let (to_network_message_tx, to_network_message_rx) = mpsc::unbounded_channel();
-        let (from_network_message_tx, from_network_message_rx) = mpsc::unbounded_channel();
+        let (from_network_message_tx, mut from_network_message_rx) = mpsc::unbounded_channel();
 
-        peers.retain(|x| *x != server_address);
-        let peers = PeerIPC::peer_startup(peers, from_network_message_tx.clone()).await;
-        let peers_addrs: Vec<Address> = peers.iter().map(|peer| peer.address.clone()).collect();
+        know_peers.retain(|x| *x != server_address);
+
+        let mut peers = vec![];
+
+        if let Some((fs_serialized, peers_addrs, ipc)) = initiate_connection(
+            know_peers,
+            server_address.clone(),
+            &from_network_message_tx,
+            &mut from_network_message_rx,
+        )
+        .await
+        {
+            peers = PeerIPC::peer_startup(peers_addrs, from_network_message_tx.clone()).await;
+            peers.push(ipc);
+            register_to_others(&peers, &server_address)?;
+            arbo.overwrite_self(fs_serialized.fs_index);
+        }
+
+        let arbo: Arc<RwLock<Arbo>> = Arc::new(RwLock::new(arbo));
+
         let network_interface = Arc::new(NetworkInterface::new(
             arbo.clone(),
             mount_point.clone(),
@@ -70,37 +144,24 @@ impl Pod {
             server_address,
         ));
 
-        let peer_broadcast_handle = Some(tokio::spawn(NetworkInterface::contact_peers(
-            network_interface.peers.clone(),
-            to_network_message_rx,
-        )));
-
         let disk_manager = DiskManager::new(mount_point.clone())?;
-
-        // TODO - maybe not mount fuse until remote arbo is pulled
         let fs_interface = Arc::new(FsInterface::new(
             network_interface.clone(),
             disk_manager,
             arbo.clone(),
         ));
 
+        // Start ability to recieve messages
         let network_airport_handle = Some(tokio::spawn(NetworkInterface::network_airport(
             from_network_message_rx,
             fs_interface.clone(),
         )));
 
-        if peers_addrs.len() >= 1 {
-            network_interface.register_to_others();
-            info!("Will pull filesystem from remote... {:?}", peers_addrs);
-            network_interface
-                .request_arbo(peers_addrs[0].clone())
-                .await?;
-
-            info!("Pull completed");
-            // debug!("arbo: {:#?}", network_interface.arbo);
-        } else {
-            info!("Created fresh new filesystem");
-        }
+        // Start ability to send messages
+        let peer_broadcast_handle = Some(tokio::spawn(NetworkInterface::contact_peers(
+            network_interface.peers.clone(),
+            to_network_message_rx,
+        )));
 
         let new_peer_handle = Some(tokio::spawn(
             NetworkInterface::incoming_connections_watchdog(

--- a/src/pods/declarations.rs
+++ b/src/pods/declarations.rs
@@ -96,7 +96,7 @@ fn register_to_others(peers: &Vec<PeerIPC>, self_address: &Address) -> std::io::
     for peer in peers {
         peer.sender
             .send((MessageContent::Register(self_address.clone()), None))
-            .map_err(|err| std::io::Error::new(io::ErrorKind::HostUnreachable, err))?;
+            .map_err(|err| std::io::Error::new(io::ErrorKind::NotConnected, err))?;
     }
     Ok(())
 }

--- a/src/pods/fs_interface.rs
+++ b/src/pods/fs_interface.rs
@@ -300,7 +300,6 @@ impl FsInterface {
                             .network_interface
                             .callbacks
                             .resolve(Callback::Pull(id), false)
-                            .map(|_| ());
                     }
                 },
                 arbo.get_inode(id)?.clone(),

--- a/src/pods/network_interface.rs
+++ b/src/pods/network_interface.rs
@@ -618,7 +618,7 @@ impl NetworkInterface {
             Ok(())
         } else {
             Err(std::io::Error::new(
-                io::ErrorKind::Deadlock,
+                io::ErrorKind::WouldBlock,
                 "Deadlock while trying to read peers",
             ))
         }

--- a/src/pods/network_interface.rs
+++ b/src/pods/network_interface.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, io, sync::Arc};
+use std::{
+    collections::HashMap,
+    io::{self, ErrorKind},
+    sync::Arc,
+};
 
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::{
@@ -561,7 +565,7 @@ impl NetworkInterface {
 
         self.to_network_message_tx
             .send(ToNetworkMessage::SpecificMessage(
-                (MessageContent::RequestFs(self.self_addr.clone()), None),
+                (MessageContent::RequestFs, None),
                 vec![to],
             ))
             .expect("request_arbo: unable to update modification on the network thread");
@@ -581,7 +585,7 @@ impl NetworkInterface {
         }
     }
 
-    pub fn send_arbo(&self, to: Address, real_address: Address) -> io::Result<()> {
+    pub fn send_arbo(&self, to: Address) -> io::Result<()> {
         let arbo = Arbo::read_lock(&self.arbo, "send_arbo")?;
         let mut entries = arbo.get_raw_entries();
 
@@ -593,39 +597,35 @@ impl NetworkInterface {
             }
         });
 
-        self.to_network_message_tx
-            .send(ToNetworkMessage::SpecificMessage(
-                (
-                    MessageContent::FsAnswer(FileSystemSerialized {
-                        fs_index: entries,
-                        next_inode: self.get_next_inode()?,
-                    }),
-                    None,
-                ),
-                vec![real_address],
+        if let Some(peers) = self.peers.try_read_for(LOCK_TIMEOUT) {
+            let peers_address_list = peers.iter().map(|peer| peer.address.clone()).collect();
+
+            self.to_network_message_tx
+                .send(ToNetworkMessage::SpecificMessage(
+                    (
+                        MessageContent::FsAnswer(
+                            FileSystemSerialized {
+                                fs_index: entries,
+                                next_inode: self.get_next_inode()?,
+                            },
+                            peers_address_list,
+                        ),
+                        None,
+                    ),
+                    vec![to],
+                ))
+                .expect("send_arbo: unable to update modification on the network thread");
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                io::ErrorKind::Deadlock,
+                "Deadlock while trying to read peers",
             ))
-            .expect("send_arbo: unable to update modification on the network thread");
-        Ok(())
+        }
     }
 
     pub fn register_new_node(&self, socket: Address, addr: Address) {
         self.edit_peer_ip(socket, addr);
-    }
-
-    // NOTE - meant only for pulling the arbo at startup !
-    // Does not care for currently ongoing business when called
-    pub fn replace_arbo(&self, new: FileSystemSerialized) -> io::Result<()> {
-        let mut arbo = Arbo::write_lock(&self.arbo, "replace_arbo")?;
-        arbo.overwrite_self(new.fs_index);
-
-        let mut next_inode = self
-            .next_inode
-            .try_lock_for(LOCK_TIMEOUT)
-            .expect("couldn't lock next_inode");
-        *next_inode = new.next_inode;
-
-        // resolve callback :
-        self.callbacks.resolve(Callback::PullFs, true)
     }
 
     pub async fn network_airport(
@@ -652,15 +652,16 @@ impl NetworkInterface {
                 }
                 MessageContent::Remove(id) => fs_interface.recept_remove_inode(id),
                 MessageContent::RequestFile(inode, peer) => fs_interface.send_file(inode, peer),
-                MessageContent::RequestFs(origin_addr) => {
-                    fs_interface.send_filesystem(origin, origin_addr)
-                }
+                MessageContent::RequestFs => fs_interface.send_filesystem(origin),
                 MessageContent::Register(addr) => Ok(fs_interface.register_new_node(origin, addr)),
                 MessageContent::Rename(parent, new_parent, name, new_name) => {
                     fs_interface.accept_rename(parent, new_parent, &name, &new_name)
                 }
-                MessageContent::FsAnswer(fs) => fs_interface.replace_arbo(fs),
                 MessageContent::RequestPull(id) => fs_interface.pull_file(id),
+                MessageContent::FsAnswer(_, _) => {
+                    Err(io::Error::new(ErrorKind::InvalidInput,
+                        "Late answer from first connection, loaded network interface shouldn't recieve FsAnswer"))
+                }
             };
             if let Err(error) = action_result {
                 log::error!("Network airport couldn't operate this operation: {error}");


### PR DESCRIPTION
Context:
To use redundancy, functions pulling files must know if the network request failed or not.
As currently we only sent a message (UnboundedSender) to the function managing network, we can't know directly if the request failed.

This PR adds a way for the network function forward_receiver_to_write (peer_ipc.rs) to give feedback to the emitter, by joining an unbounded sender to the message content.

```diff

+ pub type MessageAndFeedback = (MessageContent, Option<UnboundedSender<Feedback>>);

pub enum ToNetworkMessage {
    BroadcastMessage(MessageContent),
    SpecificMessage(
-        MessageContent
+        MessageAndFeedback,
        Vec<Address>,
    ),
}
```