### PR TITLE
replace SIG_BLOCK with EWOULDBLOCK for unix error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ impl WhError {
             WhError::InodeNotFound => libc::ENOENT,
             WhError::DeadLock => libc::EDEADLOCK,
             WhError::NetworkDied { called_from: _ } => libc::ENETDOWN,
-            WhError::WouldBlock { called_from: _ } => libc::SIG_BLOCK,
+            WhError::WouldBlock { called_from: _ } => libc::EWOULDBLOCK,
         }
     }
 }


### PR DESCRIPTION
SIG_BLOCK is an enum used by sigprocmask to block incoming signals

EWOULDBLOCK is the POSIX error code meant

SIG_BLOCK is only available in linux, merging any future windows PR will require this fix