### PR TITLE
Fix: functional tests

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev
+  workflow_dispatch:
 
 jobs:
   build:

--- a/src/commands/cli/new.rs
+++ b/src/commands/cli/new.rs
@@ -9,13 +9,21 @@ use tokio::runtime::Runtime;
 use crate::{
     commands::{
         cli::message::cli_messager,
-        cli_commands::{Cli, PodArgs}, default_local_config,
-    }, config::{types::Config, LocalConfig}, error::{CliError, CliResult}, pods::{arbo::{GLOBAL_CONFIG_FNAME, LOCAL_CONFIG_FNAME}, whpath::WhPath}
+        cli_commands::{Cli, PodArgs},
+        default_local_config,
+    },
+    config::{types::Config, LocalConfig},
+    error::{CliError, CliResult},
+    pods::{
+        arbo::{GLOBAL_CONFIG_FNAME, LOCAL_CONFIG_FNAME},
+        whpath::WhPath,
+    },
 };
 
 fn mod_file_conf_content(path: WhPath, name: String, ip: &str) -> Result<(), CliError> {
     let local_path = path.clone().join(LOCAL_CONFIG_FNAME).inner;
-    let mut local_config: LocalConfig = LocalConfig::read(&local_path).unwrap_or(default_local_config(&name));
+    let mut local_config: LocalConfig =
+        LocalConfig::read(&local_path).unwrap_or(default_local_config(&name));
     if local_config.general.name != name {
         //REVIEW - changer le nom sans prévenir l'utilisateur ou renvoyer une erreur ? Je pense qu'il serait mieux de renvoyer une erreur
         local_config.general.name = name.clone();
@@ -33,22 +41,20 @@ fn is_new_wh_file_config(path: &WhPath) -> CliResult<()> {
     let files_name = vec![LOCAL_CONFIG_FNAME, GLOBAL_CONFIG_FNAME];
     for file_name in files_name {
         if fs::metadata(path.clone().push(file_name).inner.clone()).is_err() {
-            return Err(CliError::FileConfigName { name: file_name.to_owned() });
+            return Err(CliError::FileConfigName {
+                name: file_name.to_owned(),
+            });
         }
     }
     Ok(())
 }
 
-
 //FIXME - Error id name of the pod not check (can be already exist)
 pub fn new(ip: &str, mut args: PodArgs) -> CliResult<()> {
-    let p = env::current_dir()?;
-    let path = WhPath::from(&p.display().to_string());
-    args.path = if args.path.inner != "." {
-        path.join(&args.path)
-    } else {
-        path
-    };
+    if args.path.inner == "." {
+        args.path = WhPath::from(&env::current_dir()?.display().to_string());
+    }
+
     fs::read_dir(&args.path.inner)?;
     if args.url == None {
         is_new_wh_file_config(&args.path)?;

--- a/src/fuse/fuse_impl.rs
+++ b/src/fuse/fuse_impl.rs
@@ -639,6 +639,7 @@ pub fn mount_fuse(
         MountOption::RW,
         // MountOption::DefaultPermissions,
         MountOption::FSName("wormhole".to_string()),
+        MountOption::CUSTOM("nonempty".to_string())
     ];
     let ctrl = FuseController { fs_interface };
 

--- a/src/network/ip.rs
+++ b/src/network/ip.rs
@@ -17,6 +17,10 @@ impl IpP {
         octets[3] = value;
         self.addr = Ipv4Addr::from(octets);
     }
+
+    pub fn get_ip_last(&self) -> u8 {
+        self.addr.octets()[3]
+    }
 }
 
 impl TryFrom<&String> for IpP {
@@ -32,6 +36,15 @@ impl TryFrom<&String> for IpP {
             })
         } else {
             Err("IpP: TryFrom: Invalid ip provided")
+        }
+    }
+}
+
+impl Clone for IpP {
+    fn clone(&self) -> Self {
+        Self {
+            addr: self.addr,
+            port: self.port,
         }
     }
 }

--- a/src/pods/whpath.rs
+++ b/src/pods/whpath.rs
@@ -305,7 +305,6 @@ impl WhPath {
             }
             i += 1;
         }
-        println!("j: {}", j);
         return &segment[j..];
     }
 

--- a/tests/functionnal/environnement_manager.rs
+++ b/tests/functionnal/environnement_manager.rs
@@ -1,19 +1,12 @@
 use std::{
-    os::{
-        fd::AsFd,
-        unix::{net::UnixStream, process::ExitStatusExt},
-    },
-    path::{Path, PathBuf},
-    process::ExitStatus,
+    os::{fd::AsFd, unix::net::UnixStream},
+    path::Path,
 };
 
 use assert_fs::TempDir;
 use std::process::Stdio;
-use tokio::{process::Command, task::spawn_blocking};
-use wormhole::{
-    network::{ip::IpP, message::Address},
-    pods::whpath::WhPath,
-};
+use tokio::process::Command;
+use wormhole::network::ip::IpP;
 
 pub struct Service {
     pub instance: tokio::process::Child,

--- a/tests/functionnal/environnement_manager.rs
+++ b/tests/functionnal/environnement_manager.rs
@@ -1,19 +1,27 @@
 use std::{
-    os::{fd::AsFd, unix::net::UnixStream},
-    path::PathBuf,
+    os::{
+        fd::AsFd,
+        unix::{net::UnixStream, process::ExitStatusExt},
+    },
+    path::{Path, PathBuf},
+    process::ExitStatus,
 };
 
 use assert_fs::TempDir;
 use std::process::Stdio;
-use tokio::process::Command;
+use tokio::{process::Command, task::spawn_blocking};
+use wormhole::{
+    network::{ip::IpP, message::Address},
+    pods::whpath::WhPath,
+};
 
 pub struct Service {
     pub instance: tokio::process::Child,
     #[allow(dead_code)]
-    dir: TempDir,
     #[allow(dead_code)]
     stdin: UnixStream,
-    pub path: PathBuf,
+    pub ip: IpP,
+    pub pods: Vec<(String, IpP, TempDir)>, // (network_name, ip, dir)
 }
 
 pub struct EnvironnementManager {
@@ -35,31 +43,25 @@ impl EnvironnementManager {
         }
     }
 
-    pub fn add_service(&mut self, pipe_output: bool) -> Result<(), Box<dyn std::error::Error>> {
-        let temp_dir = assert_fs::TempDir::new()?;
-
-        let new_path = temp_dir.path().to_string_lossy().to_string();
-        let new_index = self.services.len();
-        let snd_index = (new_index + 1) % 3;
-        let third_index = (new_index + 2) % 3;
-
+    pub fn add_service(
+        &mut self,
+        ip: IpP,
+        pipe_output: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mut command = Command::new("cargo");
+        command.kill_on_drop(true);
 
         // GHActions does'nt pipe a stdin so we have to make one ourselves from a FD
         let (write, read) = std::os::unix::net::UnixStream::pair()?;
 
         let stdio = Stdio::from(read.as_fd().try_clone_to_owned().unwrap());
-        command.kill_on_drop(true);
 
         let instance = command
             .args(&[
                 "run".to_string(),
                 "--bin".to_string(),
                 "wormhole-service".to_string(),
-                new_path,
-                format!("127.0.0.{}:8081", new_index + 100),
-                format!("127.0.0.{}:8081", snd_index + 100),
-                format!("127.0.0.{}:8081", third_index + 100),
+                ip.to_string(),
             ])
             .stdout(Self::generate_pipe(pipe_output))
             .stderr(Self::generate_pipe(pipe_output))
@@ -68,11 +70,102 @@ impl EnvironnementManager {
 
         self.services.push(Service {
             instance,
-            path: temp_dir.path().to_owned(),
-            dir: temp_dir,
             stdin: write,
+            ip: ip,
+            pods: Vec::new(),
         });
 
+        Ok(())
+    }
+
+    fn cli_pod_creation_command(
+        network_name: String,
+        service_ip: &IpP,
+        dir_path: &Path,
+        ip: &IpP,
+        connect_to: Option<&IpP>,
+        pipe_output: bool,
+    ) -> Result<std::process::ExitStatus, Box<dyn std::error::Error>> {
+        let mut command = Command::new("cargo");
+        command.kill_on_drop(true);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let test = rt.block_on(
+            command
+                .args({
+                    let mut args = vec![
+                        "run".to_string(),
+                        "--bin".to_string(),
+                        "wormhole-cli".to_string(),
+                        service_ip.to_string(), // service ip
+                        "new".to_string(),
+                        network_name, // network name
+                        "-C".to_string(),
+                        dir_path.to_string_lossy().to_string(),
+                        ip.to_string(),
+                    ];
+
+                    if let Some(peer) = connect_to {
+                        args.push("-u".to_string());
+                        args.push(peer.to_string());
+                    }
+                    args
+                })
+                .stdout(Self::generate_pipe(pipe_output))
+                .stderr(Self::generate_pipe(pipe_output))
+                .spawn()?
+                .wait(),
+        )?;
+        Ok(test)
+    }
+
+    /// Create a network for each service running (1 pod per service, connected to every other service's pods)
+    pub async fn create_network(
+        &mut self,
+        network_name: String,
+        pipe_output: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let last_pod_ip = self
+            .services
+            .iter()
+            .map(|service| &service.pods)
+            .flatten()
+            .max_by(|(_, ip, _), (_, ip2, _)| ip.get_ip_last().cmp(&ip2.get_ip_last()))
+            .map(|(_, ip, _)| ip.clone());
+
+        self.services
+            .iter_mut()
+            .fold(last_pod_ip, |conn_to, service| {
+                let temp_dir = assert_fs::TempDir::new().expect("can't create temp dir");
+                let mut pod_ip = conn_to
+                    .clone()
+                    .unwrap_or(IpP::try_from(&"127.0.0.1:8080".to_string()).unwrap());
+                pod_ip.set_ip_last(pod_ip.get_ip_last() + 1);
+
+                let exit_status = Self::cli_pod_creation_command(
+                    network_name.clone(),
+                    &service.ip,
+                    temp_dir.path(), // FIXME - services shoud have one path per pod
+                    &pod_ip,
+                    conn_to.as_ref(),
+                    pipe_output,
+                );
+
+                match exit_status {
+                    Ok(status) if status.success() => {
+                        service
+                            .pods
+                            .push((network_name.clone(), pod_ip.clone(), temp_dir));
+                        Some(pod_ip)
+                    }
+                    Ok(status) => panic!("Error code from the cli: {status}"),
+                    Err(e) => {
+                        panic!("Cli command to create pod failed: {e}");
+                    }
+                }
+            });
         Ok(())
     }
 }

--- a/tests/functionnal/environnement_manager.rs
+++ b/tests/functionnal/environnement_manager.rs
@@ -43,6 +43,7 @@ impl EnvironnementManager {
         }
     }
 
+    /// Create a service on the next available ip. No pods are created.
     pub fn add_service(&mut self, pipe_output: bool) -> Result<(), Box<dyn std::error::Error>> {
         let ip = self
             .services
@@ -88,6 +89,7 @@ impl EnvironnementManager {
         Ok(())
     }
 
+    /// Cli commands to create a pod
     fn cli_pod_creation_command(
         network_name: String,
         service_ip: &IpP,
@@ -141,7 +143,7 @@ impl EnvironnementManager {
             .wait()?)
     }
 
-    /// Create pod connected a network for each service running
+    /// Create pod connected to a network for each service running
     /// except if the service already has a pod on that network
     pub async fn create_network(
         &mut self,

--- a/tests/functionnal/environnement_manager.rs
+++ b/tests/functionnal/environnement_manager.rs
@@ -97,7 +97,23 @@ impl EnvironnementManager {
         pipe_output: bool,
     ) -> Result<std::process::ExitStatus, Box<dyn std::error::Error>> {
         let mut command = std::process::Command::new("cargo");
+        log::info!("Cli template command.");
+        command
+            .args(&[
+                "run".to_string(),
+                "--bin".to_string(),
+                "wormhole-cli".to_string(),
+                "template".to_string(),
+                "-C".to_string(),
+                dir_path.to_string_lossy().to_string(),
+            ])
+            .stdout(Self::generate_pipe(pipe_output))
+            .stderr(Self::generate_pipe(pipe_output))
+            .spawn()?
+            .wait()?;
 
+        let mut command = std::process::Command::new("cargo");
+        log::info!("Cli new pod command.");
         Ok(command
             .args({
                 let mut args = vec![
@@ -163,6 +179,7 @@ impl EnvironnementManager {
                         service
                             .pods
                             .push((network_name.clone(), pod_ip.clone(), temp_dir));
+                        log::info!("pod created successfully");
                         Some(pod_ip)
                     }
                     Ok(status) => panic!("Error code from the cli: {status}"),

--- a/tests/functionnal/environnement_manager.rs
+++ b/tests/functionnal/environnement_manager.rs
@@ -109,6 +109,7 @@ impl EnvironnementManager {
                     network_name, // network name
                     "-C".to_string(),
                     dir_path.to_string_lossy().to_string(),
+                    "-i".to_string(),
                     ip.to_string(),
                 ];
 
@@ -151,7 +152,7 @@ impl EnvironnementManager {
                 let exit_status = Self::cli_pod_creation_command(
                     network_name.clone(),
                     &service.ip,
-                    temp_dir.path(), // FIXME - services shoud have one path per pod
+                    temp_dir.path(),
                     &pod_ip,
                     conn_to.as_ref(),
                     pipe_output,

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -52,13 +52,6 @@ async fn sync_start_state() {
         &env.services[2].pods[0].2.path().to_owned(),
     ] {
         let path = append_to_path(path, "/bar.txt");
-        println!(
-            "files: {:#?}",
-            std::fs::read_dir(&path)
-                .expect("can't read dir")
-                .map(|p| p.unwrap().path())
-                .collect::<Vec<std::path::PathBuf>>()
-        );
         match std::fs::read_to_string(&path) {
             Err(_) => assert!(false, "File {:?} doesn't exist", path),
             Ok(_content) => assert!(

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -1,3 +1,5 @@
+use std::{fs::DirEntry, path::PathBuf};
+
 use crate::functionnal::append_to_path;
 
 use super::environnement_manager;
@@ -8,6 +10,7 @@ use serial_test::serial;
 #[serial]
 #[tokio::test]
 async fn sync_start_state() {
+    println!("====== STARTING SYNC START STATE========");
     let mut env = EnvironnementManager::new();
     env.add_service(false).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
@@ -45,12 +48,14 @@ async fn sync_start_state() {
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
-    for paths in [
+    for path in [
         &env.services[0].pods[0].2.path().to_owned(),
+        &env.services[1].pods[0].2.path().to_owned(),
         &env.services[2].pods[0].2.path().to_owned(),
     ] {
-        match std::fs::read_to_string(append_to_path(paths, "/bar.txt")) {
-            Err(_) => assert!(false, "File doesn't exist"),
+        let path = append_to_path(path, "/bar.txt");
+        match std::fs::read_to_string(&path) {
+            Err(_) => assert!(false, "File {:?} doesn't exist", path),
             Ok(_content) => assert!(
                 true,                        /*content == "Goodbye world!"*/
                 "File content is incorrect"  // No support for file streaming yet

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -1,5 +1,3 @@
-use std::{fs::DirEntry, path::PathBuf};
-
 use crate::functionnal::append_to_path;
 
 use super::environnement_manager;

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -11,15 +11,23 @@ async fn sync_start_state() {
     let mut env = EnvironnementManager::new();
     env.add_service(false).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
+    env.create_network("default".to_owned(), false)
+        .await
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
-    let file_path = append_to_path(&env.services[0].path, "/foo.txt");
+    let file_path = append_to_path(&env.services[0].pods[0].2.path().to_owned(), "/foo.txt");
     std::fs::write(&file_path, "Hello world!").unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(1.0));
 
     env.add_service(false).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
+    env.create_network("default".to_owned(), false)
+        .await
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
-    let check_path = append_to_path(&env.services[1].path, "/foo.txt");
+    let check_path = append_to_path(&env.services[1].pods[0].2.path().to_owned(), "/foo.txt");
     match std::fs::read_to_string(&check_path) {
         Err(_) => assert!(false, "File doesn't exist"),
         Ok(_content) => assert!(
@@ -28,12 +36,19 @@ async fn sync_start_state() {
         ),
     }
 
-    let file_path = append_to_path(&env.services[0].path, "/bar.txt");
+    let file_path = append_to_path(&env.services[0].pods[0].2.path().to_owned(), "/bar.txt");
     std::fs::write(&file_path, "Goodbye world!").unwrap();
     env.add_service(false).unwrap();
-    std::thread::sleep(std::time::Duration::from_secs_f32(1.5));
+    std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
+    env.create_network("default".to_owned(), false)
+        .await
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
-    for paths in [&env.services[0].path, &env.services[2].path] {
+    for paths in [
+        &env.services[0].pods[0].2.path().to_owned(),
+        &env.services[2].pods[0].2.path().to_owned(),
+    ] {
         match std::fs::read_to_string(append_to_path(paths, "/bar.txt")) {
             Err(_) => assert!(false, "File doesn't exist"),
             Ok(_content) => assert!(

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -52,6 +52,13 @@ async fn sync_start_state() {
         &env.services[2].pods[0].2.path().to_owned(),
     ] {
         let path = append_to_path(path, "/bar.txt");
+        println!(
+            "files: {:#?}",
+            std::fs::read_dir(&path)
+                .expect("can't read dir")
+                .map(|p| p.unwrap().path())
+                .collect::<Vec<std::path::PathBuf>>()
+        );
         match std::fs::read_to_string(&path) {
             Err(_) => assert!(false, "File {:?} doesn't exist", path),
             Ok(_content) => assert!(

--- a/tests/functionnal/test_sync.rs
+++ b/tests/functionnal/test_sync.rs
@@ -10,9 +10,9 @@ use serial_test::serial;
 async fn sync_start_state() {
     println!("====== STARTING SYNC START STATE========");
     let mut env = EnvironnementManager::new();
-    env.add_service(false).unwrap();
+    env.add_service(true).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
-    env.create_network("default".to_owned(), false)
+    env.create_network("default".to_owned(), true)
         .await
         .unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));

--- a/tests/functionnal/test_transfer.rs
+++ b/tests/functionnal/test_transfer.rs
@@ -24,9 +24,17 @@ async fn basic_text_file_transfer() {
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
     for paths in [
+        &env.services[0].pods[0].2.path().to_owned(),
         &env.services[1].pods[0].2.path().to_owned(),
         &env.services[2].pods[0].2.path().to_owned(),
     ] {
+        println!(
+            "files: {:#?}",
+            std::fs::read_dir(&paths)
+                .expect("can't read dir")
+                .map(|p| p.unwrap().path())
+                .collect::<Vec<std::path::PathBuf>>()
+        );
         match std::fs::read_to_string(append_to_path(paths, "/foo.txt")) {
             Ok(content) => assert!(content == "Hello world!", "File content is incorrect"),
             Err(_) => assert!(false, "File doesn't exist"),

--- a/tests/functionnal/test_transfer.rs
+++ b/tests/functionnal/test_transfer.rs
@@ -12,13 +12,20 @@ async fn basic_text_file_transfer() {
     env.add_service(false).unwrap();
     env.add_service(false).unwrap();
     env.add_service(false).unwrap();
+    std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
+    env.create_network("default".to_string(), false)
+        .await
+        .unwrap();
 
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
-    let file_path = append_to_path(&env.services[0].path, "/foo.txt");
+    let file_path = append_to_path(&env.services[0].pods[0].2.path().to_owned(), "/foo.txt");
     std::fs::write(&file_path, "Hello world!").unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
 
-    for paths in [&env.services[1].path, &env.services[2].path] {
+    for paths in [
+        &env.services[1].pods[0].2.path().to_owned(),
+        &env.services[2].pods[0].2.path().to_owned(),
+    ] {
         match std::fs::read_to_string(append_to_path(paths, "/foo.txt")) {
             Ok(content) => assert!(content == "Hello world!", "File content is incorrect"),
             Err(_) => assert!(false, "File doesn't exist"),

--- a/tests/functionnal/test_transfer.rs
+++ b/tests/functionnal/test_transfer.rs
@@ -28,13 +28,6 @@ async fn basic_text_file_transfer() {
         &env.services[1].pods[0].2.path().to_owned(),
         &env.services[2].pods[0].2.path().to_owned(),
     ] {
-        println!(
-            "files: {:#?}",
-            std::fs::read_dir(&paths)
-                .expect("can't read dir")
-                .map(|p| p.unwrap().path())
-                .collect::<Vec<std::path::PathBuf>>()
-        );
         match std::fs::read_to_string(append_to_path(paths, "/foo.txt")) {
             Ok(content) => assert!(content == "Hello world!", "File content is incorrect"),
             Err(_) => assert!(false, "File doesn't exist"),

--- a/tests/functionnal/test_transfer.rs
+++ b/tests/functionnal/test_transfer.rs
@@ -13,7 +13,7 @@ async fn basic_text_file_transfer() {
     env.add_service(false).unwrap();
     env.add_service(false).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
-    env.create_network("default".to_string(), false)
+    env.create_network("default".to_string(), true)
         .await
         .unwrap();
 

--- a/tests/functionnal/test_transfer.rs
+++ b/tests/functionnal/test_transfer.rs
@@ -8,12 +8,13 @@ use serial_test::serial;
 #[serial]
 #[tokio::test]
 async fn basic_text_file_transfer() {
+    println!("====== STARTING BASIC TEXT FILE TRANSFER ========");
     let mut env = EnvironnementManager::new();
     env.add_service(false).unwrap();
     env.add_service(false).unwrap();
     env.add_service(false).unwrap();
     std::thread::sleep(std::time::Duration::from_secs_f32(2.0));
-    env.create_network("default".to_string(), true)
+    env.create_network("default".to_string(), false)
         .await
         .unwrap();
 


### PR DESCRIPTION
# Reshape of our test framwork
Now compatible with the new cli

### EnvironnementManager:
- add_service -> create a service on the next available ip
- connect_to_network
-> Create a network between each service
  - 1 pod per service on a given network
  - Connect only services that does not currently have a pod running on this network
  - (Create temp dir, use *Cli template*, then *Cli new*)

### Cli:
- Corrected behavior on absolute paths for the `new` command
- Now returns a proper output code (0 in case of success) for commands

