### PR TITLE
fix: can't bind two pods to the same address

### DIFF
--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -203,7 +203,8 @@ async fn handle_cli_command(
         }
         _ => Err(CliError::InvalidCommand),
     };
-    let string_output = response_command.map_or_else(|e| e.to_string(), |a| a.to_string());
+    let string_output =
+        response_command.map_or_else(|e| format!("CliError: {:?}", e), |a| a.to_string());
     match writer.send(Message::Text(string_output)).await {
         Ok(()) => log::debug!("Sent answer to cli"),
         Err(err) => log::error!("Message can't send to cli: {}", err),

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -5,7 +5,10 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
-use tokio::{net::TcpListener, sync::mpsc::UnboundedReceiver};
+use tokio::{
+    net::{TcpListener, TcpSocket},
+    sync::mpsc::UnboundedReceiver,
+};
 pub type Tx = UnboundedReceiver<ToNetworkMessage>;
 pub type PeerMap = Arc<Mutex<HashMap<SocketAddr, Tx>>>;
 
@@ -16,13 +19,31 @@ pub struct Server {
 
 impl Server {
     pub async fn setup(addr: &str) -> CliResult<Server> {
+        let socket_addr: SocketAddr = addr.parse().map_err(|e| CliError::Server {
+            addr: addr.to_owned(),
+            err: std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid ip address"),
+        })?;
+
+        let socket = TcpSocket::new_v4().map_err(|e| CliError::Server {
+            addr: addr.to_owned(),
+            err: e,
+        })?;
+        socket.set_reuseaddr(false).map_err(|e| CliError::Server {
+            addr: addr.to_owned(),
+            err: e,
+        })?;
+        socket.bind(socket_addr).map_err(|e| CliError::Server {
+            addr: addr.to_owned(),
+            err: e,
+        })?;
+        let listener = socket.listen(1024).map_err(|e| CliError::Server {
+            addr: addr.to_owned(),
+            err: e,
+        })?;
+
+        log::debug!("made bind on {}", addr);
         Ok(Server {
-            listener: TcpListener::bind(addr)
-                .await
-                .map_err(|e| CliError::Server {
-                    addr: addr.to_owned(),
-                    err: e,
-                })?,
+            listener: listener,
             state: PeerMap::new(Mutex::new(HashMap::new())),
         })
     }


### PR DESCRIPTION
closes #175 
No error was given when assigning two pods to the same IP
Corrected by disabling `SO_REUSEADDR`

Due to the current state of the cli, the way the error is reported is dirty. See #171 
