### PR TITLE
FIX: mirror action happens on PUSH not on PR

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,11 +4,14 @@ env:
   MIRROR_URL: git@github.com:EpitechPromo2026/G-EIP-700-PAR-7-1-eip-axel.denis.git
 
 on:
-  pull_request:
+  push:
     branches: ["main"]
+  workflow_dispatch: # Allow manual triggers
 
 jobs:
   push_to_mirror:
+    if:
+      github.repository == ‘Agartha-Software/Wormhole’ # disable Forks trying this job (even if it would safely fail)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- also disables attempting the mirror action on forks, even if it would safely fail