### PR TITLE
fix: fixed too many parameters on release function

### DIFF
--- a/src/winfsp/winfsp_impl.rs
+++ b/src/winfsp/winfsp_impl.rs
@@ -293,7 +293,7 @@ impl FileSystemContext for FSPController {
         log::trace!("winfsp::close({:?});", context);
         let _ = self
             .fs_interface
-            .release(context.handle, context.ino)
+            .release(context.handle)
             .inspect_err(|e| log::warn!("close::{e};"));
     }
 


### PR DESCRIPTION
Just a little fix that prevented windows from building