### PR TITLE
fix(unix_disk_manager): use /proc/self/fd instead of AT_EMPTY_PATH 

### DIFF
--- a/src/pods/disk_managers/unix_disk_manager.rs
+++ b/src/pods/disk_managers/unix_disk_manager.rs
@@ -102,15 +102,28 @@ impl DiskManager for UnixDiskManager {
 
     fn set_permisions(&self, path: &WhPath, permissions: u16) -> std::io::Result<()> {
         let raw_fd: RawFd = self.handle.as_raw_fd();
-        let c_string_path =
-            CString::new::<&str>(path.as_ref()).expect("panics if there are internal null bytes");
+
+        // Either create a relative path within the wh backing
+        // or an absolute path pointing to the 'magic link' of the aliased mountpoint
+        // at functions treat absolute paths transparently
+        let c_string_path = if path.is_empty() {
+            CString::new(format!("/proc/self/fd/{raw_fd}"))
+        } else {
+            CString::new::<&str>(path.as_ref())
+        }
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Path contains internal null bytes is unsupported",
+            )
+        })?;
 
         let ptr: *const i8 = c_string_path.as_ptr();
         let result = unsafe {
             // If we just self.handle.open_file...set_permission, the open flags
             // don't allow to modify the permission on a file where we don't have the permission like a 000
             // This is the only convincing way we found
-            libc::fchmodat(raw_fd, ptr, permissions.into(), libc::AT_EMPTY_PATH)
+            libc::fchmodat(raw_fd, ptr, permissions.into(), 0)
         };
         if result != 0 {
             Err(std::io::Error::last_os_error())

--- a/src/pods/whpath.rs
+++ b/src/pods/whpath.rs
@@ -214,6 +214,10 @@ impl WhPath {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.inner.as_str().is_empty()
+    }
+
     /// Allows for a easy path.typed_ref<T>() instead of a heavy rust type notation of AsRef
     pub fn typed_ref<T>(&self) -> &T
     where


### PR DESCRIPTION
AT_EMPTY_PATH was introduced in linux 6.6
this would allow us to support older versions of Linux 